### PR TITLE
Changes from Class Components to Functional Components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,34 +1,28 @@
 import "./App.css";
-import React from "react";
+import React, { useState } from "react";
 import Ticker from "./components/Ticker";
 import CommandBar from "./components/CommandBar";
 import FooterBar from "./components/FooterBar";
 
-export default class App extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      ticker: null,
-      listofTicker: [],
-    };
-  }
-  
-  handleCallback = (commandBarData) => {
-    this.setState({ ticker: commandBarData });
-    this.state.listofTicker.push(commandBarData);
-  };
+function App() {
+	//const [ticker, setTicker] = useState('');
+	const [listOfTicker, setlistOfTicker] = useState([]);
 
-  render() {
-    const tickerlist = this.state.listofTicker;
-    return (
-      <div>
-        <CommandBar tickerCallback={this.handleCallback} />
-        <Ticker
-          //key={tickerlist} ---- uncomment this if you want every line to reload on submit, otherwise it'll just load a new ticker below the current one
-          listofTickers={tickerlist}
-        />
-        <FooterBar />
-      </div>
-    );
-  }
+	const handleCallback = (commandBarData) => {
+    //take the commandBarData and append it to the listOfTicker
+		setlistOfTicker([...listOfTicker, commandBarData.ticker]);
+	};
+
+	return (
+		<div>
+			<CommandBar tickerCallback={handleCallback} />
+			<Ticker
+				//key={tickerlist} ---- uncomment this if you want every line to reload on submit, otherwise it'll just load a new ticker below the current one
+				tickerlist={listOfTicker}
+			/>
+			<FooterBar />
+		</div>
+	);
 }
+
+export default App;

--- a/src/components/CommandBar.js
+++ b/src/components/CommandBar.js
@@ -25,10 +25,12 @@ function CommandBar(props) {
 				<Form inline onSubmit={handleSubmit} id="tickerForm">
 					<FormControl
 						autoComplete="off"
+            autoCorrect="off" 
+            spellCheck="false"
 						placeholder="/tickertron"
 						aria-label="ticker"
 						id="ticker-bar"
-						value={ticker.ticker}
+						value={ticker.value}
 						onChange={handleChange}
 					/>
 				</Form>

--- a/src/components/CommandBar.js
+++ b/src/components/CommandBar.js
@@ -10,8 +10,8 @@ function CommandBar(props) {
 	};
 
 	const handleSubmit = (event) => {
-		//as opposed to the class, the tickerCallback passes a ticker object instead of the string value.
-		//We handle this in App.js by grabbing only what we need.
+    //as opposed to the class, the tickerCallback passes a ticker object instead of the string value.
+    //We handle this in App.js by grabbing only what we need.
 		props.tickerCallback(ticker);
 		event.preventDefault();
 		event.target.reset();

--- a/src/components/CommandBar.js
+++ b/src/components/CommandBar.js
@@ -1,51 +1,47 @@
-import React from "react";
-import {
-    Navbar,
-    Form,
-    FormControl
-} from 'react-bootstrap'
-import './style/CommandBar.css'
+import { React, useState } from "react";
+import { Navbar, Form, FormControl } from "react-bootstrap";
+import "./style/CommandBar.css";
 
-export default class CommandBar extends React.Component {  
+function CommandBar(props) {
+	const [ticker, setTicker] = useState("");
 
-  constructor(props) {
-    super(props)
-    this.state = {
-        ticker: ''
-    }
-    //binds the change and submit handlers
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
+	const handleChange = (event) => {
+		setTicker({ ticker: event.target.value });
+	};
+
+	const handleSubmit = (event) => {
+		//as opposed to the class, the tickerCallback passes a ticker object instead of the string value.
+		//We handle this in App.js by grabbing only what we need.
+		props.tickerCallback(ticker);
+		event.preventDefault();
+		event.target.reset();
+		//reset the state
+		setTicker({ ticker: "" });
+	};
+
+	return (
+		<div className="commandBar">
+			<Navbar>
+				<Form inline onSubmit={handleSubmit} id="tickerForm">
+					<FormControl
+						autoComplete="off"
+						placeholder="/tickertron"
+						aria-label="ticker"
+						id="ticker-bar"
+						value={ticker.ticker}
+						onChange={handleChange}
+					/>
+				</Form>
+			</Navbar>
+		</div>
+	);
 }
-
-handleChange(event) {
-    this.setState({ ticker: event.target.value });
-}
-
-handleSubmit(event) {
-  this.props.tickerCallback(this.state.ticker);
-  event.preventDefault();
-  event.target.reset();
-  //reset the state
-  this.setState({ticker:''})         
-}
-  render() {
-    return (
-      <div className="commandBar">
-        <Navbar>
-            <Form inline onSubmit={this.handleSubmit} id="tickerForm"> 
-                <FormControl autoComplete="off" placeholder="/tickertron" aria-label="ticker" id="ticker-bar" value={this.state.value} onChange={this.handleChange} /> 
-            </Form>
-        </Navbar>
-      </div>
-    );
-  }
-}
-
 document.addEventListener("keypress", function onPress(event) {
-  if (event.key === "/") {
-    const input = document.getElementById('ticker-bar');
-    input.select();
-    event.preventDefault();
-  } 
+	if (event.key === "/") {
+		const input = document.getElementById("ticker-bar");
+		input.select();
+		event.preventDefault();
+	}
 });
+
+export default CommandBar;

--- a/src/components/FooterBar.js
+++ b/src/components/FooterBar.js
@@ -3,8 +3,7 @@ import { Navbar } from "react-bootstrap";
 import './style/FooterBar.css'
 import ghLogo from "./img/github-logo-32.png";
 
-export default class FooterBar extends React.Component {
-  render() {
+function Footerbar(){
     return (
       <div>
         <Navbar fixed="bottom" className="justify-content-end">
@@ -20,5 +19,6 @@ export default class FooterBar extends React.Component {
         </Navbar>
       </div>
     );
-  }
 }
+
+export default Footerbar;

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react'
+import React from "react";
 import { Spinner } from "react-bootstrap";
 
-export default class Loading extends Component {
-    render() {
-        return (
-            <Spinner animation="border" role="status">
-				<span className="sr-only">Loading...</span>
-			</Spinner>
-        )
-    }
+function Loading() {
+	return (
+		<Spinner animation="border" role="status">
+			<span className="sr-only">Loading...</span>
+		</Spinner>
+	);
 }
+
+export default Loading;

--- a/src/components/Ticker.js
+++ b/src/components/Ticker.js
@@ -1,43 +1,56 @@
-import React from "react";
-import { Col, Row} from "react-bootstrap";
+import React, { useState, useEffect } from "react";
+import { Col, Row } from "react-bootstrap";
 import Tickerline from "./Tickerline";
 import "./style/Ticker.css";
 import Loading from "./Loading";
 require("dotenv").config();
 
-export default class Ticker extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			allTickers: {},
-			tickersLoaded: false,
-			todayStart: "",
-			currentTime: ""
-		};
-	}
+function Ticker(props) {
+	const [allTickers, setallTickers] = useState("");
+	const [tickersLoaded, settickersLoaded] = useState(false);
+	const [todayStart, settodayStart] = useState("");
+	const [currentTime, setcurrentTime] = useState("");
 
-	getToday() {
+	const getToday = () => {
 		var d = new Date();
 		d.setDate(d.getDate());
 		d.setHours(8, 30, 1, 0);
 
 		var unix = Math.floor(d.getTime() / 1000);
 
-		this.setState({
+		settodayStart({
 			todayStart: unix
 		});
-	}
+	};
 
-	getCurrentTime() {
+	const getCurrentTime = () => {
 		var d = new Date();
 		var unix = Math.floor(d.getTime() / 1000);
 
-		this.setState({
+		setcurrentTime({
 			currentTime: unix
 		});
-	}
+	};
 
-	renderHeader() {
+	const grabAllTickers = () => {
+		const cs =
+			"https://finnhub.io/api/v1/stock/symbol?exchange=US&token=" + process.env.REACT_APP_MY_KEY;
+		fetch(cs)
+			.then((res) => res.json())
+			.then((result) => {
+				setallTickers({ allTickers: result });
+				settickersLoaded({ tickersLoaded: true });
+			});
+		getCurrentTime();
+		getToday();
+	};
+
+	useEffect(() => {
+		grabAllTickers();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const renderHeader = () => {
 		return (
 			<Row xs={1} md={2} lg={2}>
 				<Col xl={2} style={{ color: "gray" }}>
@@ -57,45 +70,24 @@ export default class Ticker extends React.Component {
 				</Col>
 			</Row>
 		);
-	}
+	};
 
-	async grabAllTickers() {
-		const cs =
-			"https://finnhub.io/api/v1/stock/symbol?exchange=US&token=" + process.env.REACT_APP_MY_KEY;
-		await fetch(cs)
-			.then((res) => res.json())
-			.then((result) => {
-				this.setState({
-					allTickers: result,
-					//sets tickersLoaded to true when the inital fetch has completed
-					tickersLoaded: true
-				});
-			});
-			this.getCurrentTime();
-			this.getToday();
-			
-	}
-
-	async componentDidMount() {
-		await this.grabAllTickers();
-	}
-
-	render() {
-		return (
-			<div className="tickerContainer">
-				{this.state.tickersLoaded ? this.renderHeader() : <Loading />}
-				{this.props.listofTickers.map((tickers) => {
-					return (
-						<Tickerline
-							tickerToUse={tickers}
-							key={tickers}
-							allTickers={this.state.allTickers}
-							todayStart={this.state.todayStart}
-							currentTime={this.state.currentTime}
-						/>
-					);
-				})}
-			</div>
-		);
-	}
+	return (
+		<div className="tickerContainer">
+			{tickersLoaded ? renderHeader() : <Loading />}
+			{props.tickerlist.map((tickers) => {
+				return (
+					<Tickerline
+						tickerToUse={tickers}
+						key={tickers}
+						allTickers={allTickers.allTickers}
+						todayStart={todayStart.todayStart}
+						currentTime={currentTime.currentTime}
+					/>
+				);
+			})}
+		</div>
+	);
 }
+
+export default Ticker;

--- a/src/components/Ticker.js
+++ b/src/components/Ticker.js
@@ -6,10 +6,10 @@ import Loading from "./Loading";
 require("dotenv").config();
 
 function Ticker(props) {
-	const [allTickers, setallTickers] = useState("");
+	const [allTickers, setallTickers] = useState();
 	const [tickersLoaded, settickersLoaded] = useState(false);
-	const [todayStart, settodayStart] = useState("");
-	const [currentTime, setcurrentTime] = useState("");
+	const [todayStart, settodayStart] = useState();
+	const [currentTime, setcurrentTime] = useState();
 
 	const getToday = () => {
 		var d = new Date();
@@ -32,22 +32,21 @@ function Ticker(props) {
 		});
 	};
 
-	const grabAllTickers = () => {
-		const cs =
-			"https://finnhub.io/api/v1/stock/symbol?exchange=US&token=" + process.env.REACT_APP_MY_KEY;
-		fetch(cs)
-			.then((res) => res.json())
-			.then((result) => {
-				setallTickers({ allTickers: result });
-				settickersLoaded({ tickersLoaded: true });
-			});
-		getCurrentTime();
-		getToday();
-	};
-
 	useEffect(() => {
+		const grabAllTickers = async () => {
+			const cs =
+				"https://finnhub.io/api/v1/stock/symbol?exchange=US&token=" + process.env.REACT_APP_MY_KEY;
+			await fetch(cs)
+				.then((res) => res.json())
+				.then((result) => {
+					setallTickers({ allTickers: result });
+					settickersLoaded({ tickersLoaded: true });
+				});
+			getCurrentTime();
+			getToday();
+		};
+
 		grabAllTickers();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const renderHeader = () => {


### PR DESCRIPTION
This PR changes the majority of the components to be functional components instead of classes. This was done both to increase knowledge of React Hooks and improve overall readability. The Tickerline and StockChart components were left as class components due to their complexity and to keep reference. There may come a day in the future where these also are migrated.